### PR TITLE
Fix undefined service handling in Mosquitto script

### DIFF
--- a/restart_mosquitto.bat
+++ b/restart_mosquitto.bat
@@ -1,6 +1,16 @@
 @echo off
 echo Restarting Mosquitto SERVICE...
-net stop mosquitto >nul
+net stop mosquitto >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    echo Warning: Could not stop the service. It may not be running.
+) else (
+    echo Mosquitto service stopped.
+)
+
 net start mosquitto
-echo ✅ Mosquitto restarted successfully.
+if %ERRORLEVEL% NEQ 0 (
+    echo Failed to start Mosquitto service. Please check if it's properly installed.
+) else (
+    echo ✅ Mosquitto restarted successfully.
+)
 pause

--- a/setup_mosquitto.bat
+++ b/setup_mosquitto.bat
@@ -4,13 +4,13 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 :: === PARAMETERS ===
 set MOSQ_VER=2.0.21a
 set MOSQ_URL=https://mosquitto.org/files/binary/win64/mosquitto-%MOSQ_VER%-install-windows-x64.exe
-set MOSQ_INSTALL_DIR="C:\Program Files\mosquitto"
+set MOSQ_INSTALL_DIR=C:\Program Files\mosquitto
 set CONF_FILE=mosquitto.conf
 set FIREWALL_RULE=MQTT_PORT_1883
 
 :: === DOWNLOAD AND INSTALLATION ===
 echo Downloading Mosquitto version %MOSQ_VER%...
-powershell -Command "Invoke-WebRequest -Uri %MOSQ_URL% -OutFile mosquitto-installer.exe"
+powershell -Command "Invoke-WebRequest -Uri '%MOSQ_URL%' -OutFile 'mosquitto-installer.exe'"
 
 echo Silent installation...
 start /wait mosquitto-installer.exe /S
@@ -18,12 +18,12 @@ start /wait mosquitto-installer.exe /S
 :: === COPYING CONFIGURATION FILE ===
 IF EXIST "%~dp0%CONF_FILE%" (
     echo Copying custom configuration file...
-    copy /Y "%~dp0%CONF_FILE%" %MOSQ_INSTALL_DIR%\mosquitto.conf
+    copy /Y "%~dp0%CONF_FILE%" "%MOSQ_INSTALL_DIR%\mosquitto.conf"
 )
 
 :: === CREATING PERSISTENCE & LOG FOLDERS ===
-mkdir "%MOSQ_INSTALL_DIR%\log" >nul 2>&1
-mkdir "%MOSQ_INSTALL_DIR%\data" >nul 2>&1
+if not exist "%MOSQ_INSTALL_DIR%\log" mkdir "%MOSQ_INSTALL_DIR%\log" >nul 2>&1
+if not exist "%MOSQ_INSTALL_DIR%\data" mkdir "%MOSQ_INSTALL_DIR%\data" >nul 2>&1
 
 :: === FIREWALL CONFIGURATION ===
 echo Adding firewall rule for port 1883...
@@ -33,6 +33,7 @@ netsh advfirewall firewall add rule name="%FIREWALL_RULE%" dir=in action=allow p
 sc query mosquitto >nul 2>&1
 IF %ERRORLEVEL% NEQ 0 (
     echo Installing Mosquitto service...
+    cd /d "%MOSQ_INSTALL_DIR%"
     "%MOSQ_INSTALL_DIR%\mosquitto.exe" -install
 )
 


### PR DESCRIPTION
Improve error handling for starting and stopping the Mosquitto service, ensuring clearer messages when the service is not running or fails to start. Adjust installation script for better path handling and conditionally create necessary directories.